### PR TITLE
Various build fixes

### DIFF
--- a/bt/BehaviorTree.hpp
+++ b/bt/BehaviorTree.hpp
@@ -10,8 +10,8 @@ class BehaviorTree : public Node
 {
 public:
     BehaviorTree() : blackboard(std::make_shared<Blackboard>()) {}
-    BehaviorTree(const Node::Ptr &rootNode) : BehaviorTree(), root(rootNode) {}
-    BehaviorTree(const Blackboard::Ptr &shared) : BehaviorTree(), sharedBlackboard(shared) {}
+    BehaviorTree(const Node::Ptr &rootNode) : BehaviorTree() { root = rootNode; }
+    BehaviorTree(const Blackboard::Ptr &shared) : BehaviorTree() { sharedBlackboard = shared; }
     
     Status Update() { return root->Tick(); }
     

--- a/bt/composites/MemSelector.hpp
+++ b/bt/composites/MemSelector.hpp
@@ -41,7 +41,7 @@ public:
     using Ptr = std::shared_ptr<MemSelector>;
 };
 
-MemSelector::Ptr MakeMemSelector()
+static MemSelector::Ptr MakeMemSelector()
 {
     return std::make_shared<MemSelector>();
 }

--- a/bt/composites/MemSequence.hpp
+++ b/bt/composites/MemSequence.hpp
@@ -41,7 +41,7 @@ public:
     using Ptr = std::shared_ptr<MemSequence>;
 };
 
-MemSequence::Ptr MakeMemSequence()
+static MemSequence::Ptr MakeMemSequence()
 {
     return std::make_shared<MemSequence>();
 }

--- a/bt/composites/ParallelSequence.hpp
+++ b/bt/composites/ParallelSequence.hpp
@@ -65,7 +65,7 @@ private:
     int minFail = 0;
 };
 
-ParallelSequence::Ptr MakeParallelSequence()
+static ParallelSequence::Ptr MakeParallelSequence()
 {
     return std::make_shared<ParallelSequence>();
 }

--- a/bt/composites/Selector.hpp
+++ b/bt/composites/Selector.hpp
@@ -45,7 +45,7 @@ public:
     using Ptr = std::shared_ptr<Selector>;
 };
 
-Selector::Ptr MakeSelector()
+static Selector::Ptr MakeSelector()
 {
     return std::make_shared<Selector>();
 }

--- a/bt/composites/Sequence.hpp
+++ b/bt/composites/Sequence.hpp
@@ -45,7 +45,7 @@ public:
     using Ptr = std::shared_ptr<Sequence>;
 };
 
-Sequence::Ptr MakeSequence()
+static Sequence::Ptr MakeSequence()
 {
     return std::make_shared<Sequence>();
 }

--- a/bt/decorators/Repeater.hpp
+++ b/bt/decorators/Repeater.hpp
@@ -24,7 +24,7 @@ public:
             auto s = child->Tick();
 
             if (s == Status::Running) {
-                break;
+                return Status::Running;
             }
 
             if (s == Status::Failure) {


### PR DESCRIPTION
- Make constructor functions static to avoid duplicate symbols when including bt.hpp in several compilation units.
- Don't combine delegated constructors with initializers.
- Make sure Repeater always returns a status.
